### PR TITLE
Public View V1 + Seeded Data + Switched from Postgres_changes to Polling

### DIFF
--- a/backend/src/controllers/currentStates/userCurrentStateController.ts
+++ b/backend/src/controllers/currentStates/userCurrentStateController.ts
@@ -17,6 +17,8 @@ export class UserCurrentStateController {
                 res.status(404).json({ error: 'User state not found' });
             }
 
+            //TODO: change location to lat and long
+
             res.json(userState);
         } catch (error) {
             res.status(500).json({ error: 'Failed to get user state' });
@@ -25,6 +27,7 @@ export class UserCurrentStateController {
 
     upsertUserState = async (req: Request, res: Response) => {
         try {
+            console.log('upserting user state');
             const { userId } = req.params;
             const userStateData = req.body;
 
@@ -42,15 +45,17 @@ export class UserCurrentStateController {
 
     getPublicUsers = async (req: Request, res: Response) => {
         try {
-            const { longitude, latitude, radius, maxResults } = req.query;
+            console.log('!!!!!!!!!!!!getting Public users in controller!!!');
+            const { userId, longitude, latitude, radius, maxResults } = req.query;
 
             const publicUsers = await this.userCurrentStateService.getPublicUsers(
+                userId as string,
                 Number(longitude), // Number() is alternative to parseFloat and +operator
                 Number(latitude),
                 Number(radius),
                 maxResults ? Number(maxResults) : undefined // If undefined, use default value
             );
-
+            console.log('publicUsers!!!', publicUsers);
             res.json(publicUsers);
         } catch (error) {
             res.status(500).json({ error: 'Failed to get public users' });

--- a/backend/src/controllers/spotify/tracks/currentTrackController.ts
+++ b/backend/src/controllers/spotify/tracks/currentTrackController.ts
@@ -29,6 +29,7 @@ export class CurrentTrackController {
             }
 
             const accessToken = data.provider_data.access_token;
+            console.log('accessToken', accessToken);
 
             this.currentTrackService.startPollingCurrentTrack(userId, accessToken);
             res.json({ success: true, message: 'Started polling for currently playing track' });

--- a/backend/src/routes/userStates/index.ts
+++ b/backend/src/routes/userStates/index.ts
@@ -4,16 +4,18 @@ import { UserCurrentStateController } from '../../controllers/currentStates/user
 const router = Router();
 const userCurrentStateController = new UserCurrentStateController();
 
-// Get a given user's current state
-router.get('/:userId', userCurrentStateController.getUserState);
-
-// Update a given user's current state
-router.put('/:userId', userCurrentStateController.upsertUserState);
+// Note: route order matters - if public is after /:userId, it will never be hit as it will think that public is the userId
 
 // Fetch public view for a given user (don't need their id just location)
 router.get('/public', userCurrentStateController.getPublicUsers);
 
 // Fetch friends view for a given user (need id and location)
 router.get('/friends/:userId', userCurrentStateController.getCloseFriends);
+
+// Get a given user's current state
+router.get('/:userId', userCurrentStateController.getUserState);
+
+// Update a given user's current state
+router.put('/:userId', userCurrentStateController.upsertUserState);
 
 export default router;

--- a/backend/src/services/auth/spotifyService.ts
+++ b/backend/src/services/auth/spotifyService.ts
@@ -42,7 +42,6 @@ export class SpotifyAuthService {
 	 */
     async handleCallback(code: string): Promise<SpotifyAuthResponse> {
         const data = await this.spotifyApi.authorizationCodeGrant(code);
-		console.log('we in here', data);
 
 		// Retrieve new user data
         const tokens = {

--- a/backend/src/services/currentStates/userCurrentStateService.ts
+++ b/backend/src/services/currentStates/userCurrentStateService.ts
@@ -21,17 +21,15 @@ export class UserCurrentStateService {
      */
     async getUserState(userId: string): Promise<UserCurrentState[]> {
         const { data: state, error } = await supabase
-            .from('current_user_states')
-            .select('*')
-            .eq('id', userId)
-            .single();
+        .rpc('get_user_state', { user_id: userId });
 
         if (error) {
-            // TODO: keep adding console.errors everywhere -- really helps with debugging
+            // TODO: keep adding console.errors everywhere -- really helps with debugging!
             console.error('Error in getUserState:', error);
-           throw error;
+            throw error;
         }
-        return state;
+
+        return state[0];
     }
 
     /**
@@ -64,9 +62,16 @@ export class UserCurrentStateService {
     /**
      * GET method - Public View: @returns all users within given radius around a given location
      */
-    async getPublicUsers(longitude: number, latitude: number, radius: number, maxResults: number = 50): Promise<UserCurrentState[]> {
+    async getPublicUsers(userId: string, longitude: number, latitude: number, radius: number, maxResults: number = 50): Promise<UserCurrentState[]> {
+        console.log('getting public users in service!!!');
+        console.log('userId', userId);
+        console.log('longitude', longitude);
+        console.log('latitude', latitude);
+        console.log('radius', radius);
+        console.log('maxResults', maxResults);
         const { data: nearbyUsers, error: publicError } = await supabase
             .rpc('get_nearby_user_states', {
+                user_id: userId,
                 longitude,
                 latitude,
                 radius_miles: radius,
@@ -74,9 +79,9 @@ export class UserCurrentStateService {
             });
 
         if (publicError) {
+            console.error('Error in getPublicUsers:', publicError);
             throw publicError;
         }
-
         return nearbyUsers;
     }
 

--- a/backend/src/services/spotify/tracks/currentTrackService.ts
+++ b/backend/src/services/spotify/tracks/currentTrackService.ts
@@ -36,7 +36,9 @@ export class CurrentTrackService {
     startPollingCurrentTrack(userId: string, accessToken: string) {
         this.stopPollingCurrentTrack(userId);
 
-        const POLLING_INTERVAL = 60000; // 60 seconds
+        console.log('starting polling for current track'); // Not getting in here
+
+        const POLLING_INTERVAL = 5000; // 5 seconds
 
         const intervalId = setInterval(async () => {
             try {
@@ -76,8 +78,7 @@ export class CurrentTrackService {
         if (track.type === 'track') {
             const { error } = await supabase
                 .from('current_user_states')
-                .upsert({
-                    id: userId,
+                .update({
                     current_track_id: track.id,
                     track_name: track.name,
                     artist_name: track.artists.map(artist => artist.name).join(', '),
@@ -85,9 +86,8 @@ export class CurrentTrackService {
                     album_image_url: track.album.images?.[0]?.url,
                     is_playing: trackData.is_playing,
                     updated_at: new Date().toISOString(),
-                }, {
-                    onConflict: 'id',
-                });
+                })
+                .eq('id', userId);
 
             if (error) {
                 console.error('Error updating current track:', error);

--- a/frontend/src/components/auth/SpotifyLoginButton.tsx
+++ b/frontend/src/components/auth/SpotifyLoginButton.tsx
@@ -57,17 +57,19 @@ const SpotifyLoginButton = ({ onLoginSuccess }: SpotifyLoginButtonProps) => {
         'user-follow-read',
       ],
       usePKCE: false,
-      redirectUri: 'https://crescendo-fork.onrender.com/api/auth/spotify/callback',
-      //makeRedirectUri({
-      //   scheme: 'crescendo',
-      //   path: 'auth/callback',
-      // }),
+      redirectUri: makeRedirectUri({
+        scheme: 'crescendo',
+        path: 'auth/callback',
+      }),
     },
     discovery
   );
 
   //print redirect uri
-  const redirectUri = 'https://crescendo-fork.onrender.com/api/auth/spotify/callback';
+  const redirectUri = makeRedirectUri({
+    scheme: 'crescendo',
+    path: 'auth/callback',
+  });
   console.log('Redirect URI:', redirectUri);
 
   // Handle authentication response - wait for code from Spotify, then use code to get refresh token
@@ -109,7 +111,6 @@ const SpotifyLoginButton = ({ onLoginSuccess }: SpotifyLoginButtonProps) => {
     }
   }, [response, handleAuthCode]);
 
-  //useUserTracking(true);
 
 const handleLogin = useCallback(() => {
   promptAsync();

--- a/frontend/src/components/mapView/MapView.jsx
+++ b/frontend/src/components/mapView/MapView.jsx
@@ -27,6 +27,7 @@ import listenersData from '../../data/listeners.json';
 import {FontAwesome5} from '@expo/vector-icons';
 
 import { useUserStates } from '../../hooks/useUserStates.ts';
+import { useUserTracking } from '../../hooks/useUserTracking.ts';
 
 
 // Icon components
@@ -69,7 +70,9 @@ const COLLAPSED_HEIGHT = height * 0.3; // 30% of screen height
 const EXPANDED_HEIGHT = height * 0.7; // 70% of screen height
 
 const MapScreen = ({navigation}) => {
-  const { me, friends } = useUserStates('public');
+
+  useUserTracking(true);
+  const { me, friends } = useUserStates('friends');
 
   const [location, setLocation] = useState({
     latitude: me?.latitude || 37.7749,

--- a/frontend/src/hooks/useUserTracking.ts
+++ b/frontend/src/hooks/useUserTracking.ts
@@ -30,7 +30,7 @@ export const useUserTracking = (isAuthenticated: boolean) => {
             return;
             }
 
-            // Get initial location and setup tracking
+            // Get initial location and setup music tracking
             const initialLocation = await Location.getCurrentPositionAsync({});
             console.log('initialLocation', initialLocation); // TODO: check why not being updated in DB
             await userTrackingService.setupTracking(userId, initialLocation);
@@ -40,7 +40,7 @@ export const useUserTracking = (isAuthenticated: boolean) => {
                 {accuracy: Location.Accuracy.Highest},
                 async (activeLocation) => {
                 // Update location in DB
-                await userTrackingService.updateLocation(userId, activeLocation); // TODO: Implement this
+                await userTrackingService.updateLocation(userId, activeLocation);
                 }
             );
 

--- a/frontend/src/services/userTrackingService.ts
+++ b/frontend/src/services/userTrackingService.ts
@@ -9,7 +9,8 @@ export const userTrackingService = {
         await userTrackingService.updateLocation(userId, initialLocation);
 
         // Start backend polling for current track
-        await fetch(`${API_BASE_URL}/api/tracks/spotify/currentTrack/startPolling/${userId}`, {
+        console.log('starting backend polling for current track w/ user id', userId); // Not getting in here
+        await fetch(`${API_BASE_URL}/api/tracks/spotify/startPolling/${userId}`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -46,13 +47,17 @@ export const userTrackingService = {
     },
 
     // Public view: Get all users within given radius given current user's location
-    getPublicUsers: async (longitude: number, latitude: number, radius: number = 1000, maxResults?: number) => {
+    getPublicUsers: async (userId: string, longitude: number, latitude: number, radius: number = 1000, maxResults?: number) => {
+        console.log('getting public users, about to hit endpoint!!!');
         const queryParams = new URLSearchParams({
+            userId: userId,
             longitude: longitude.toString(),
             latitude: latitude.toString(),
             radius: radius.toString(),
             ...(maxResults && { maxResults: maxResults.toString() }),
         });
+
+        console.log('queryParams', queryParams.toString()); // hmm - why is this empty?
 
         const response = await fetch(`${API_BASE_URL}/api/states/public?${queryParams}`);
         if (!response.ok) {

--- a/supabase/seeds/01_users.sql
+++ b/supabase/seeds/01_users.sql
@@ -4,17 +4,30 @@
 --     music_provider_id,
 --     provider_data,
 --     created_at
--- ) VALUES (
---     '365630b7-9f05-4d73-b162-072523b6cbd8',
---     'spotify',
---     'luugx89189zpbfmhrsa23zsr0',
---     '{
---       "email": "negativezeroisanumber@gmail.com",
---       "display_name": "Negativezeroisanumber",
---       "profile_image_url": "https://i.scdn.co/image/ab6775700000ee850858aab00bbd37622c2165cc",
---       "access_token": "BQBB77Ids0nAoLwunTT5nYSHxEdwUNX2Iz_4sG8zYfdVKqGrJIy1Is1L2tTqInaOQLUjC09jzyInj1NcyEncbqOE4dLv0jS8giRhHeHoJUyC6ppxoMWC7JSnTQ5hvC1veoXJWUIjsi1KR1_ID1qbytpCrUBn1ROxlo9AI5FMiHRv7suO0Mu33aYY90sIH0VCDOos77PHdQctTlUgPTXJsMX0d8EBxNRXt5ZNMFr_gv9emfGxt6OrOHvMf4UYxk8uS9SF6RtukcmF9wjMibEFwGt-wWlMTdwBVpDkBDTcNa5AF_je2mVF2xfwHrPZGzh3xDPYeMrdqAZbgxn1ARdgdBtVavee4mpJg2Pa2UUn3lw",
---       "refresh_token": "AQDRFl2o5Np9xIhZU-tzuW5Oq9Jz5wiKrfhiE9L79So7JkRkoPgmRwozhVW-DBYf1WwHKgWzDngcBu9LOg6FZm1VYYceidCa59NE-aF5u0TcfyTPxhx4UF1xREqxp75xlng",
---       "token_expires_at": "2025-05-01T20:49:14.857+00:00"
---     }',
---     '2025-05-01 20:49:14.857+00'
--- );
+-- ) VALUES
+-- ('365630b7-9f05-4d73-b162-072523b6cbd8', 'spotify', 'luugx89189zpbfmhrsa23zsr0', '{
+--   "email": "negativezeroisanumber@gmail.com",
+--   "display_name": "Negativezeroisanumber",
+--   "profile_image_url": "https://i.scdn.co/image/ab6775700000ee850858aab00bbd37622c2165cc",
+--   "access_token": "token1",
+--   "refresh_token": "refresh1",
+--   "token_expires_at": "2025-05-01T20:49:14.857+00:00"
+-- }', '2025-05-01 20:49:14.857+00'),
+
+INSERT INTO users (
+    id,
+    music_provider,
+    music_provider_id,
+    provider_data,
+    created_at
+) VALUES
+('365630b7-9f05-4d73-b162-072523b6cbd8', 'spotify', 'luugx89189zpbfmhrsa23zsr0', '{}', '2025-05-01 20:49:14.857+00'),
+('1a2b3c4d-5e6f-4a8b-9c0d-1e2f3a4b5c6d', 'spotify', 'user2id', '{}', '2025-05-01 20:49:14.857+00'),
+('2b3c4d5e-6f7a-4b9c-8d0e-2f3a4b5c6d7e', 'spotify', 'user3id', '{}', '2025-05-01 20:49:14.857+00'),
+('3c4d5e6f-7a8b-4c9d-0e1f-3a4b5c6d7e8f', 'spotify', 'user4id', '{}', '2025-05-01 20:49:14.857+00'),
+('4d5e6f7a-8b9c-4d0e-1f2a-4b5c6d7e8f9a', 'spotify', 'user5id', '{}', '2025-05-01 20:49:14.857+00'),
+('5e6f7a8b-9c0d-4e1f-2a3b-5c6d7e8f9a0b', 'spotify', 'user6id', '{}', '2025-05-01 20:49:14.857+00'),
+('6f7a8b9c-0d1e-4f2a-3b4c-6d7e8f9a0b1c', 'spotify', 'user7id', '{}', '2025-05-01 20:49:14.857+00'),
+('7a8b9c0d-1e2f-4a3b-5c6d-7e8f9a0b1c2d', 'spotify', 'user8id', '{}', '2025-05-01 20:49:14.857+00'),
+('8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e', 'spotify', 'user9id', '{}', '2025-05-01 20:49:14.857+00'),
+('9c0d1e2f-3a4b-4c5d-7e8f-9a0b1c2d3e4f', 'spotify', 'user10id', '{}', '2025-05-01 20:49:14.857+00');

--- a/supabase/seeds/02_user_profiles.sql
+++ b/supabase/seeds/02_user_profiles.sql
@@ -1,27 +1,20 @@
--- INSERT INTO user_profiles (
---     user_id,
---     profile_image_url,
---     display_name,
---     bio,
---     followers,
---     privacy_level,
---     favorite_song,
---     favorite_artist,
---     favorite_album,
---     created_at,
---     updated_at
--- )
-
--- VALUES (
---     'luugx89189zpbfmhrsa23zsr0',
---     'https://i.scdn.co/image/ab6775700000ee850858aab00bbd37622c2165cc',
---     'Negativezeroisanumber',
---     'I am a music lover and a software engineer.',
---     0,
---     'friends_only',
---     'Shape of You',
---     'Ed Sheeran',
---     'Divide',
---     '2025-05-01 20:49:14.857+00',
---     '2025-05-01 20:49:14.857+00'
--- );
+INSERT INTO user_profiles (
+    id,
+    profile_image_url,
+    display_name,
+    bio,
+    privacy_level,
+    favorite_song,
+    favorite_artist,
+    favorite_album
+) VALUES
+('365630b7-9f05-4d73-b162-072523b6cbd8', 'https://i.scdn.co/image/ab6761610000e5eb4293385d324db8558179afd9', 'Alex Chen', 'Music enthusiast and vinyl collector', 'everyone', 'Bohemian Rhapsody', 'Queen', 'A Night at the Opera'),
+('1a2b3c4d-5e6f-4a8b-9c0d-1e2f3a4b5c6d', 'https://i.scdn.co/image/ab6761610000e5eb437b9e3a1c84938e3c0b8a1b', 'Sarah Miller', 'Live music lover', 'friends_only', 'Dreams', 'Fleetwood Mac', 'Rumours'),
+('2b3c4d5e-6f7a-4b9c-8d0e-2f3a4b5c6d7e', 'https://i.scdn.co/image/ab6761610000e5eb7a6f8c713826f3dbfd0c3b1b', 'James Wilson', 'Guitarist and songwriter', 'friends_only', 'Purple Rain', 'Prince', 'Purple Rain'),
+('3c4d5e6f-7a8b-4c9d-0e1f-3a4b5c6d7e8f', 'https://i.scdn.co/image/ab6761610000e5eb7a6f8c713826f3dbfd0c3b1b', 'Emma Thompson', 'Indie music fan', 'nobody', 'Motion Picture Soundtrack', 'Radiohead', 'Kid A'),
+('4d5e6f7a-8b9c-4d0e-1f2a-4b5c6d7e8f9a', 'https://i.scdn.co/image/ab6761610000e5eb7a6f8c713826f3dbfd0c3b1b', 'Michael Brown', 'Jazz enthusiast', 'everyone', 'So What', 'Miles Davis', 'Kind of Blue'),
+('5e6f7a8b-9c0d-4e1f-2a3b-5c6d7e8f9a0b', 'https://i.scdn.co/image/ab6761610000e5eb7a6f8c713826f3dbfd0c3b1b', 'Lisa Anderson', 'Classical music lover', 'friends_only', 'Moonlight Sonata', 'Beethoven', 'Moonlight Sonata'),
+('6f7a8b9c-0d1e-4f2a-3b4c-6d7e8f9a0b1c', 'https://i.scdn.co/image/ab6761610000e5eb7a6f8c713826f3dbfd0c3b1b', 'David Kim', 'Hip-hop producer', 'everyone', 'N.Y. State of Mind', 'Nas', 'Illmatic'),
+('7a8b9c0d-1e2f-4a3b-5c6d-7e8f9a0b1c2d', 'https://i.scdn.co/image/ab6761610000e5eb7a6f8c713826f3dbfd0c3b1b', 'Rachel Green', 'Pop music fan', 'friends_only', 'Like a Prayer', 'Madonna', 'Like a Prayer'),
+('8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e', 'https://i.scdn.co/image/ab6761610000e5eb7a6f8c713826f3dbfd0c3b1b', 'Tom Martinez', 'Rock guitarist', 'everyone', 'Stairway to Heaven', 'Led Zeppelin', 'Led Zeppelin IV'),
+('9c0d1e2f-3a4b-4c5d-7e8f-9a0b1c2d3e4f', 'https://i.scdn.co/image/ab6761610000e5eb7a6f8c713826f3dbfd0c3b1b', 'Sophie Lee', 'Electronic music producer', 'friends_only', 'Windowlicker', 'Aphex Twin', 'Windowlicker');

--- a/supabase/seeds/03_current_user_states.sql
+++ b/supabase/seeds/03_current_user_states.sql
@@ -1,0 +1,21 @@
+INSERT INTO current_user_states (
+    id,
+    current_track_id,
+    track_name,
+    artist_name,
+    album_name,
+    album_image_url,
+    location,
+    is_playing,
+    updated_at
+) VALUES
+('365630b7-9f05-4d73-b162-072523b6cbd8', 'track1', 'Song One', 'Artist A', 'Album X', 'https://i.scdn.co/image/1', gis.ST_GeogFromText('SRID=4326;POINT(-73.9857 40.7484)'), true, '2025-05-01 20:49:14.857+00'),
+('1a2b3c4d-5e6f-4a8b-9c0d-1e2f3a4b5c6d', 'track2', 'Song Two', 'Artist B', 'Album Y', 'https://i.scdn.co/image/2', gis.ST_GeogFromText('SRID=4326;POINT(-73.1625 44.0113)'), false, '2025-05-01 20:49:14.857+00'),-- in radius
+('2b3c4d5e-6f7a-4b9c-8d0e-2f3a4b5c6d7e', 'track3', 'Song Three', 'Artist C', 'Album Z', 'https://i.scdn.co/image/3', gis.ST_GeogFromText('SRID=4326;POINT(-0.1276 51.5074)'), true, '2025-05-01 20:49:14.857+00'),
+('3c4d5e6f-7a8b-4c9d-0e1f-3a4b5c6d7e8f', 'track4', 'Song Four', 'Artist D', 'Album W', 'https://i.scdn.co/image/4', gis.ST_GeogFromText('SRID=4326;POINT(2.3522 48.8566)'), false, '2025-05-01 20:49:14.857+00'),
+('4d5e6f7a-8b9c-4d0e-1f2a-4b5c6d7e8f9a', 'track5', 'Song Five', 'Artist E', 'Album V', 'https://i.scdn.co/image/5', gis.ST_GeogFromText('SRID=4326;POINT(-73.1459 44.0337)'), true, '2025-05-01 20:49:14.857+00'), -- in radius
+('5e6f7a8b-9c0d-4e1f-2a3b-5c6d7e8f9a0b', 'track6', 'Song Six', 'Artist F', 'Album U', 'https://i.scdn.co/image/6', gis.ST_GeogFromText('SRID=4326;POINT(151.2093 -33.8688)'), false, '2025-05-01 20:49:14.857+00'),
+('6f7a8b9c-0d1e-4f2a-3b4c-6d7e8f9a0b1c', 'track7', 'Song Seven', 'Artist G', 'Album T', 'https://i.scdn.co/image/7', gis.ST_GeogFromText('SRID=4326;POINT(-73.1728 43.9831)'), true, '2025-05-01 20:49:14.857+00'), -- in radius
+('7a8b9c0d-1e2f-4a3b-5c6d-7e8f9a0b1c2d', 'track8', 'Song Eight', 'Artist H', 'Album S', 'https://i.scdn.co/image/8', gis.ST_GeogFromText('SRID=4326;POINT(18.4241 -33.9249)'), false, '2025-05-01 20:49:14.857+00'),
+('8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e', 'track9', 'Song Nine', 'Artist I', 'Album R', 'https://i.scdn.co/image/9', gis.ST_GeogFromText('SRID=4326;POINT(28.0473 -26.2041)'), true, '2025-05-01 20:49:14.857+00'),
+('9c0d1e2f-3a4b-4c5d-7e8f-9a0b1c2d3e4f', 'track10', 'Song Ten', 'Artist J', 'Album Q', 'https://i.scdn.co/image/10', gis.ST_GeogFromText('SRID=4326;POINT(31.2357 30.0444)'), false, '2025-05-01 20:49:14.857+00');


### PR DESCRIPTION
Fully connected public view with back-end, although the data is still fake since we don't have users to test. 
Switched from postgres changes to polling to re-fetch user's state and nearby users' states on a per-interval basis as the DB  changes were not being represented on the map.

Smaller details: decided to not pull the user when we fetch nearby users for the list, but user's info could be helpful to at least display on the map what it is they are listening to. Would just need to change the get_nearby_users SQL func to rever this functionality and decide not to list the user on the front-end nearby listeners list but still display their display_name and track_name on the map.
